### PR TITLE
Bump tbdex & web5 packages to latest versions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,3 @@ SEC_DB_PORT=
 SEC_DB_USER=
 SEC_DB_PASSWORD=
 SEC_DB_NAME=
-
-# DID info - copy from console output
-SEC_DID=
-SEC_DID_PRIVATE_KEY=
-SEC_DID_KID=

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "tbdex-mock-pfi",
       "version": "1.0.0",
       "dependencies": {
-        "@tbdex/http-server": "0.18.0",
+        "@tbdex/http-server": "0.23.0",
         "@web5/common": "0.2.1",
         "@web5/crypto": "0.2.1",
         "@web5/dids": "0.2.1",
@@ -306,6 +306,11 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
     "node_modules/@multiformats/base-x": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
@@ -420,9 +425,9 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
-      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
+      "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -512,14 +517,14 @@
       }
     },
     "node_modules/@tbdex/http-client": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@tbdex/http-client/-/http-client-0.18.0.tgz",
-      "integrity": "sha512-3U1ThNRmzZ0WYgNM0Zj2SRdZPMX4FbbbmKp0UUJxLnUDQPcReelEmb6cbRcjeX11DoL0VrU7MKQXu47PyuOJCA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tbdex/http-client/-/http-client-0.23.0.tgz",
+      "integrity": "sha512-hh4y4vfapymJ7sZdHxYj3V75uTZf1bfQWLFfqDebzvciiQanqb5ELYRo05MrnbK/LUrZA+M5vJ6gTBa0GrIe0g==",
       "dependencies": {
-        "@tbdex/protocol": "0.18.0",
-        "@web5/common": "0.2.0",
-        "@web5/crypto": "0.2.0",
-        "@web5/dids": "0.2.0",
+        "@tbdex/protocol": "0.23.0",
+        "@web5/common": "0.2.1",
+        "@web5/crypto": "0.2.2",
+        "@web5/dids": "0.2.2",
         "query-string": "8.1.0"
       }
     },
@@ -534,58 +539,48 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@tbdex/http-client/node_modules/@web5/common": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.0.tgz",
-      "integrity": "sha512-JRJ2D0OhtyPCcvHNfzuTAkVKviy4abA5z6OlYM5ZatR3abyLVt/L6HjDKTXBuBzR49tUQcffSqJ9+EdJ5knp+w==",
-      "dependencies": {
-        "level": "8.0.0",
-        "multiformats": "11.0.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@tbdex/http-client/node_modules/@web5/crypto": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.0.tgz",
-      "integrity": "sha512-JjtP5D5FUO7yiIlyUI8RpuzyFtM8Xpchsl8XzMq9M0ZwK3aVckEAf1VMdiaHpDzESYORXAdK39yJ/t+vG7hT9w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.2.tgz",
+      "integrity": "sha512-vHFg0wXQSQXrwuBNQyDHnmSZchfTfO6/Sv+7rDsNkvofs+6lGTE8CZ02cwUYMeIwTRMLer12c+fMfzYrXokEUQ==",
       "dependencies": {
         "@noble/ciphers": "0.1.4",
         "@noble/curves": "1.1.0",
         "@noble/hashes": "1.3.1",
-        "@web5/common": "0.2.0"
+        "@web5/common": "0.2.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@tbdex/http-client/node_modules/@web5/dids": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.0.tgz",
-      "integrity": "sha512-vA9+0SAo+51va1LZZCMKSpzWqw2aN+emKNK5ej31aPGvHxrMT87d+dtjF35eorfpeBWvlQ6LxcccdTQ4zT+mWg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.2.tgz",
+      "integrity": "sha512-dARcpQIMzmayINWFemxP+shhfHLtYB+ZXoSZ1TKKnjF7qzraL30KwBSDwaNEPYaAzgo0x/1rvyv+zAgfa5MeNw==",
       "dependencies": {
         "@decentralized-identity/ion-pow-sdk": "1.0.17",
         "@decentralized-identity/ion-sdk": "1.0.1",
-        "@web5/common": "0.2.0",
-        "@web5/crypto": "0.2.0",
-        "canonicalize": "2.0.0",
+        "@web5/common": "0.2.1",
+        "@web5/crypto": "0.2.2",
         "did-resolver": "4.1.0",
+        "dns-packet": "5.6.1",
         "level": "8.0.0",
-        "ms": "2.1.3"
+        "ms": "2.1.3",
+        "pkarr": "1.1.1",
+        "z32": "1.0.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@tbdex/http-server": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@tbdex/http-server/-/http-server-0.18.0.tgz",
-      "integrity": "sha512-CAttn5fDJ90uuFLM3bo9slQzxoHy34HWZewUOI7zkeF4KfbmjTTwiDpv3ElSfdU8Eq/eYnvSmBc+cGnpvbqhaA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tbdex/http-server/-/http-server-0.23.0.tgz",
+      "integrity": "sha512-EF6agoPWqw3MvsIBdSdhDnUPfnJkjh2GZ6+3q3NsKRfK0n0/zfRmtC16PDAtewvoXa7cGWkRk7MF/NdM5MeCkw==",
       "dependencies": {
-        "@tbdex/http-client": "0.18.0",
-        "@tbdex/protocol": "0.18.0",
-        "@web5/dids": "0.2.0",
+        "@tbdex/http-client": "0.23.0",
+        "@tbdex/protocol": "0.23.0",
+        "@web5/dids": "0.2.2",
         "cors": "2.8.5",
         "express": "4.18.2"
       }
@@ -601,88 +596,65 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@tbdex/http-server/node_modules/@web5/common": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.0.tgz",
-      "integrity": "sha512-JRJ2D0OhtyPCcvHNfzuTAkVKviy4abA5z6OlYM5ZatR3abyLVt/L6HjDKTXBuBzR49tUQcffSqJ9+EdJ5knp+w==",
-      "dependencies": {
-        "level": "8.0.0",
-        "multiformats": "11.0.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@tbdex/http-server/node_modules/@web5/crypto": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.0.tgz",
-      "integrity": "sha512-JjtP5D5FUO7yiIlyUI8RpuzyFtM8Xpchsl8XzMq9M0ZwK3aVckEAf1VMdiaHpDzESYORXAdK39yJ/t+vG7hT9w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.2.tgz",
+      "integrity": "sha512-vHFg0wXQSQXrwuBNQyDHnmSZchfTfO6/Sv+7rDsNkvofs+6lGTE8CZ02cwUYMeIwTRMLer12c+fMfzYrXokEUQ==",
       "dependencies": {
         "@noble/ciphers": "0.1.4",
         "@noble/curves": "1.1.0",
         "@noble/hashes": "1.3.1",
-        "@web5/common": "0.2.0"
+        "@web5/common": "0.2.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@tbdex/http-server/node_modules/@web5/dids": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.0.tgz",
-      "integrity": "sha512-vA9+0SAo+51va1LZZCMKSpzWqw2aN+emKNK5ej31aPGvHxrMT87d+dtjF35eorfpeBWvlQ6LxcccdTQ4zT+mWg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.2.tgz",
+      "integrity": "sha512-dARcpQIMzmayINWFemxP+shhfHLtYB+ZXoSZ1TKKnjF7qzraL30KwBSDwaNEPYaAzgo0x/1rvyv+zAgfa5MeNw==",
       "dependencies": {
         "@decentralized-identity/ion-pow-sdk": "1.0.17",
         "@decentralized-identity/ion-sdk": "1.0.1",
-        "@web5/common": "0.2.0",
-        "@web5/crypto": "0.2.0",
-        "canonicalize": "2.0.0",
+        "@web5/common": "0.2.1",
+        "@web5/crypto": "0.2.2",
         "did-resolver": "4.1.0",
+        "dns-packet": "5.6.1",
         "level": "8.0.0",
-        "ms": "2.1.3"
+        "ms": "2.1.3",
+        "pkarr": "1.1.1",
+        "z32": "1.0.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@tbdex/protocol": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@tbdex/protocol/-/protocol-0.18.0.tgz",
-      "integrity": "sha512-t4Mh2Qziay9Bmgds3Nt+m5/dlT8TFUmnizts7873hpYES9Y0njq3e/c7ZvzKiwPKUs2rRAdNv1TqnI88cG7M5A==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tbdex/protocol/-/protocol-0.23.0.tgz",
+      "integrity": "sha512-oL50rKySDZ3YRPxIvBj1EZHNqOlZulRF9VHXskLynmWZcPLrCJGtenQ1T3CVVJ8KdQs5UPpc1pCLL1/Sv1IplQ==",
       "dependencies": {
         "@noble/hashes": "1.3.2",
-        "@sphereon/pex": "2.1.0",
-        "@sphereon/pex-models": "2.0.3",
-        "@web5/common": "0.2.0",
-        "@web5/credentials": "0.3.0",
-        "@web5/crypto": "0.2.0",
-        "@web5/dids": "0.2.0",
+        "@web5/common": "0.2.1",
+        "@web5/credentials": "0.3.2",
+        "@web5/crypto": "0.2.2",
+        "@web5/dids": "0.2.2",
         "ajv": "8.12.0",
+        "bignumber.js": "^9.1.2",
         "canonicalize": "2.0.0",
         "typeid-js": "0.3.0"
       }
     },
-    "node_modules/@tbdex/protocol/node_modules/@web5/common": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.0.tgz",
-      "integrity": "sha512-JRJ2D0OhtyPCcvHNfzuTAkVKviy4abA5z6OlYM5ZatR3abyLVt/L6HjDKTXBuBzR49tUQcffSqJ9+EdJ5knp+w==",
-      "dependencies": {
-        "level": "8.0.0",
-        "multiformats": "11.0.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@tbdex/protocol/node_modules/@web5/crypto": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.0.tgz",
-      "integrity": "sha512-JjtP5D5FUO7yiIlyUI8RpuzyFtM8Xpchsl8XzMq9M0ZwK3aVckEAf1VMdiaHpDzESYORXAdK39yJ/t+vG7hT9w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.2.tgz",
+      "integrity": "sha512-vHFg0wXQSQXrwuBNQyDHnmSZchfTfO6/Sv+7rDsNkvofs+6lGTE8CZ02cwUYMeIwTRMLer12c+fMfzYrXokEUQ==",
       "dependencies": {
         "@noble/ciphers": "0.1.4",
         "@noble/curves": "1.1.0",
         "@noble/hashes": "1.3.1",
-        "@web5/common": "0.2.0"
+        "@web5/common": "0.2.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -700,18 +672,20 @@
       }
     },
     "node_modules/@tbdex/protocol/node_modules/@web5/dids": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.0.tgz",
-      "integrity": "sha512-vA9+0SAo+51va1LZZCMKSpzWqw2aN+emKNK5ej31aPGvHxrMT87d+dtjF35eorfpeBWvlQ6LxcccdTQ4zT+mWg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.2.tgz",
+      "integrity": "sha512-dARcpQIMzmayINWFemxP+shhfHLtYB+ZXoSZ1TKKnjF7qzraL30KwBSDwaNEPYaAzgo0x/1rvyv+zAgfa5MeNw==",
       "dependencies": {
         "@decentralized-identity/ion-pow-sdk": "1.0.17",
         "@decentralized-identity/ion-sdk": "1.0.1",
-        "@web5/common": "0.2.0",
-        "@web5/crypto": "0.2.0",
-        "canonicalize": "2.0.0",
+        "@web5/common": "0.2.1",
+        "@web5/crypto": "0.2.2",
         "did-resolver": "4.1.0",
+        "dns-packet": "5.6.1",
         "level": "8.0.0",
-        "ms": "2.1.3"
+        "ms": "2.1.3",
+        "pkarr": "1.1.1",
+        "z32": "1.0.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1123,9 +1097,9 @@
       }
     },
     "node_modules/@web5/credentials": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@web5/credentials/-/credentials-0.3.0.tgz",
-      "integrity": "sha512-wHPsZRIxXh2uWQ3apHrj6Pl2km0tTHB/aNLBnae6LHDgh+QBaEuXodyj7fDFJ4yeMIq3LIBM7Xb6kWldHsxDEA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@web5/credentials/-/credentials-0.3.2.tgz",
+      "integrity": "sha512-hxLJfmOngglgHvIzVtxlKYFHn2atnxhH6RZCCruoHGCNVEVcKG5wXZl6D4FJ/BMlIr8SwUg8RW/I0ns0O31vqw==",
       "dependencies": {
         "@sphereon/pex": "2.1.0",
         "did-jwt": "^7.2.6",
@@ -1389,11 +1363,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1414,6 +1401,25 @@
         }
       ]
     },
+    "node_modules/bencode": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-3.1.1.tgz",
+      "integrity": "sha512-btsxX9201yoWh45TdqYg6+OZ5O1xTYKTYSGvJndICDFtznE/9zXgow8yjMvvhOqKKuzuL7h+iiCMpfkG8+QuBA==",
+      "dependencies": {
+        "uint8-util": "^2.1.6"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1421,6 +1427,67 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bittorrent-dht": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-11.0.5.tgz",
+      "integrity": "sha512-R09D6uNaziRqsc+B/j5QzkjceTak+wH9vcNLnkmt8A52EWF9lQwBP0vvCKgSA3AJOYYl+41n3osA2KYYn/z5uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "bencode": "^4.0.0",
+        "debug": "^4.3.4",
+        "k-bucket": "^5.1.0",
+        "k-rpc": "^5.1.0",
+        "last-one-wins": "^1.0.4",
+        "lru": "^3.1.0",
+        "randombytes": "^2.1.0",
+        "record-cache": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/bittorrent-dht/node_modules/bencode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-4.0.0.tgz",
+      "integrity": "sha512-AERXw18df0pF3ziGOCyUjqKZBVNH8HV3lBxnx5w0qtgMIk4a1wb9BkcCQbkp9Zstfrn/dzRwl7MmUHHocX3sRQ==",
+      "dependencies": {
+        "uint8-util": "^2.2.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/blake2b": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
+      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
+      "dependencies": {
+        "blake2b-wasm": "^2.4.0",
+        "nanoassert": "^2.0.0"
+      }
+    },
+    "node_modules/blake2b-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
+      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "nanoassert": "^2.0.0"
       }
     },
     "node_modules/body-parser": {
@@ -1592,6 +1659,14 @@
         "cborg": "lib/bin.js"
       }
     },
+    "node_modules/chacha20-universal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chacha20-universal/-/chacha20-universal-1.0.4.tgz",
+      "integrity": "sha512-/IOxdWWNa7nRabfe7+oF+jVkGjlr2xUL4J8l/OvzZhj+c9RpMqoo3Dq+5nU1j/BflRV4BKnaQ4+4oH1yBpQG1Q==",
+      "dependencies": {
+        "nanoassert": "^2.0.0"
+      }
+    },
     "node_modules/chai": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
@@ -1693,6 +1768,59 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/chrome-dgram": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.6.tgz",
+      "integrity": "sha512-bqBsUuaOiXiqxXt/zA/jukNJJ4oaOtc7ciwqJpZVEaaXwwxqgI2/ZdG02vXYWUhHGziDlvGMQWk0qObgJwVYKA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "run-series": "^1.1.9"
+      }
+    },
+    "node_modules/chrome-dns": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chrome-dns/-/chrome-dns-1.0.1.tgz",
+      "integrity": "sha512-HqsYJgIc8ljJJOqOzLphjAs79EUuWSX3nzZi2LNkzlw3GIzAeZbaSektC8iT/tKvLqZq8yl1GJu5o6doA4TRbg==",
+      "dependencies": {
+        "chrome-net": "^3.3.2"
+      }
+    },
+    "node_modules/chrome-net": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/chrome-net/-/chrome-net-3.3.4.tgz",
+      "integrity": "sha512-Jzy2EnzmE+ligqIZUsmWnck9RBXLuUy6CaKyuNMtowFG3ZvLt8d+WBJCTPEludV0DHpIKjAOlwjFmTaEdfdWCw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "inherits": "^2.0.1"
       }
     },
     "node_modules/classic-level": {
@@ -1840,7 +1968,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1856,8 +1983,7 @@
     "node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/decamelize": {
       "version": "4.0.0",
@@ -1970,9 +2096,9 @@
       }
     },
     "node_modules/did-jwt": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-7.4.4.tgz",
-      "integrity": "sha512-OW9CwDvHx0E2qjrRfy8wm5sJekXxJqGrAZXgdfhYpHEHX31Kn7Cz9gShrpGlIqYFsEsEAsA5xhFIidKAawyNCg==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-7.4.7.tgz",
+      "integrity": "sha512-Apz7nIfIHSKWIMaEP5L/K8xkwByvjezjTG0xiqwKdnNj1x8M0+Yasury5Dm/KPltxi2PlGfRPf3IejRKZrT8mQ==",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",
         "@noble/curves": "^1.0.0",
@@ -1980,34 +2106,23 @@
         "@scure/base": "^1.1.3",
         "canonicalize": "^2.0.0",
         "did-resolver": "^4.1.0",
-        "multiformats": "^12.0.0",
-        "uint8arrays": "^4.0.3"
+        "multibase": "^4.0.6",
+        "multiformats": "^9.6.2",
+        "uint8arrays": "3.1.1"
       }
     },
     "node_modules/did-jwt/node_modules/@noble/ciphers": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.4.0.tgz",
-      "integrity": "sha512-xaUaUUDWbHIFSxaQ/pIe+33VG2mfJp6N/KxKLmZr5biWdNznCAmfu24QRhX10BbVAuqOahAoyp0S4M9md6GPDw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.4.1.tgz",
+      "integrity": "sha512-QCOA9cgf3Rc33owG0AYBB9wszz+Ul2kramWN8tXG44Gyciud/tbkEqvxRF/IpqQaBpRBNi9f4jdNxqB2CQCIXg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/did-jwt/node_modules/multiformats": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
-      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/did-jwt/node_modules/uint8arrays": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.6.tgz",
-      "integrity": "sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==",
-      "dependencies": {
-        "multiformats": "^12.0.1"
-      }
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/did-resolver": {
       "version": "4.1.0",
@@ -2033,6 +2148,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/doctrine": {
@@ -2955,6 +3081,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-goodbye": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/graceful-goodbye/-/graceful-goodbye-1.3.0.tgz",
+      "integrity": "sha512-hcZOs20emYlTM7MmUE0FpuZcjlk2GPsR+UYTHDeWxtGjXcbh2CawGi8vlzqsIvspqAbot7mRv3sC/uhgtKc4hQ==",
+      "dependencies": {
+        "safety-catch": "^1.0.2"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3519,6 +3653,40 @@
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
       "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
+    "node_modules/k-bucket": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.1.0.tgz",
+      "integrity": "sha512-Fac7iINEovXIWU20GPnOMLUbjctiS+cnmyjC4zAUgvs3XPf1vo9akfCHkigftSic/jiKqKl+KA3a/vFcJbHyCg==",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/k-rpc": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-5.1.0.tgz",
+      "integrity": "sha512-FGc+n70Hcjoa/X2JTwP+jMIOpBz+pkRffHnSl9yrYiwUxg3FIgD50+u1ePfJUOnRCnx6pbjmVk5aAeB1wIijuQ==",
+      "dependencies": {
+        "k-bucket": "^5.0.0",
+        "k-rpc-socket": "^1.7.2",
+        "randombytes": "^2.0.5"
+      }
+    },
+    "node_modules/k-rpc-socket": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.11.1.tgz",
+      "integrity": "sha512-8xtA8oqbZ6v1Niryp2/g4GxW16EQh5MvrUylQoOG+zcrDff5CKttON2XUXvMwlIHq4/2zfPVFiinAccJ+WhxoA==",
+      "dependencies": {
+        "bencode": "^2.0.0",
+        "chrome-dgram": "^3.0.2",
+        "chrome-dns": "^1.0.0",
+        "chrome-net": "^3.3.2"
+      }
+    },
+    "node_modules/k-rpc-socket/node_modules/bencode": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-2.0.3.tgz",
+      "integrity": "sha512-D/vrAD4dLVX23NalHwb8dSvsUsxeRPO8Y7ToKA015JQYq69MLDOMkC0uGZYA/MPpltLO8rt8eqFC2j8DxjTZ/w=="
+    },
     "node_modules/keyv": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
@@ -3570,6 +3738,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/last-one-wins": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/last-one-wins/-/last-one-wins-1.0.4.tgz",
+      "integrity": "sha512-t+KLJFkHPQk8lfN6WBOiGkiUXoub+gnb2XTYI2P3aiISL+94xgZ1vgz1SXN/N4hthuOoLXarXfBZPUruyjQtfA=="
     },
     "node_modules/level": {
       "version": "8.0.0",
@@ -3692,6 +3865,17 @@
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/lru": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz",
+      "integrity": "sha512-5OUtoiVIGU4VXBOshidmtOsvBIvcQR6FD/RzWSvaeHyxCGB+PCUCu+52lqMfdc0h/2CLvHhZS4TwUmMQrrMbBQ==",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/lru-cache": {
@@ -3990,10 +4174,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+    },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -4132,12 +4321,12 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
@@ -4478,6 +4667,34 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkarr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkarr/-/pkarr-1.1.1.tgz",
+      "integrity": "sha512-X27LKqf83X3WuJd2Z9qdfVxkmfOu6HUbY0pm11LqeBbFmgmZRPgOxJG8bKiIsmmD6Vjc25j45KHYflF2lfodyQ==",
+      "dependencies": {
+        "bencode": "^3.0.3",
+        "bittorrent-dht": "^11.0.4",
+        "chalk": "^5.2.0",
+        "dns-packet": "^5.6.1",
+        "graceful-goodbye": "^1.3.0",
+        "sodium-universal": "^4.0.0",
+        "z32": "^1.0.0"
+      },
+      "bin": {
+        "pkarr": "bin.js"
+      }
+    },
+    "node_modules/pkarr/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
@@ -4605,7 +4822,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -4642,6 +4858,14 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/record-cache": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.2.0.tgz",
+      "integrity": "sha512-kyy3HWCez2WrotaL3O4fTn0rsIdfRKOdQQcEJ9KpvmKmbffKVvwsloX063EgRUlpJIXHiDQFhJcTbZequ2uTZw==",
+      "dependencies": {
+        "b4a": "^1.3.1"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -4805,13 +5029,32 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/run-series": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
+      "integrity": "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-array-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-      "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+      "integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
+        "call-bind": "^1.0.5",
+        "get-intrinsic": "^1.2.2",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
@@ -4842,13 +5085,16 @@
       ]
     },
     "node_modules/safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.2.tgz",
+      "integrity": "sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "call-bind": "^1.0.5",
+        "get-intrinsic": "^1.2.2",
         "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4858,6 +5104,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/safety-catch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.2.tgz",
+      "integrity": "sha512-C1UYVZ4dtbBxEtvOcpjBaaD27nP8MlvyAQEp2fOTOEe6pfUpk1cDUxij6BR1jZup6rSyUTaBBplK7LanskrULA=="
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -4982,6 +5233,42 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/sha256-universal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sha256-universal/-/sha256-universal-1.2.1.tgz",
+      "integrity": "sha512-ghn3muhdn1ailCQqqceNxRgkOeZSVfSE13RQWEg6njB+itsFzGVSJv+O//2hvNXZuxVIRyNzrgsZ37SPDdGJJw==",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "sha256-wasm": "^2.2.1"
+      }
+    },
+    "node_modules/sha256-wasm": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/sha256-wasm/-/sha256-wasm-2.2.2.tgz",
+      "integrity": "sha512-qKSGARvao+JQlFiA+sjJZhJ/61gmW/3aNLblB2rsgIxDlDxsJPHo8a1seXj12oKtuHVgJSJJ7QEGBUYQN741lQ==",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "nanoassert": "^2.0.0"
+      }
+    },
+    "node_modules/sha512-universal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sha512-universal/-/sha512-universal-1.2.1.tgz",
+      "integrity": "sha512-kehYuigMoRkIngCv7rhgruLJNNHDnitGTBdkcYbCbooL8Cidj/bS78MDxByIjcc69M915WxcQTgZetZ1JbeQTQ==",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "sha512-wasm": "^2.3.1"
+      }
+    },
+    "node_modules/sha512-wasm": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/sha512-wasm/-/sha512-wasm-2.3.4.tgz",
+      "integrity": "sha512-akWoxJPGCB3aZCrZ+fm6VIFhJ/p8idBv7AWGFng/CZIrQo51oQNsvDbTSRXWAzIiZJvpy16oIDiCCPqTe21sKg==",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "nanoassert": "^2.0.0"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5055,6 +5342,14 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/siphash24": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.3.1.tgz",
+      "integrity": "sha512-moemC3ZKiTzH29nbFo3Iw8fbemWWod4vNs/WgKbQ54oEs6mE6XVlguxvinYjB+UmaE0PThgyED9fUkWvirT8hA==",
+      "dependencies": {
+        "nanoassert": "^2.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5062,6 +5357,45 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sodium-javascript": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.8.0.tgz",
+      "integrity": "sha512-rEBzR5mPxPES+UjyMDvKPIXy9ImF17KOJ32nJNi9uIquWpS/nfj+h6m05J5yLJaGXjgM72LmQoUbWZVxh/rmGg==",
+      "dependencies": {
+        "blake2b": "^2.1.1",
+        "chacha20-universal": "^1.0.4",
+        "nanoassert": "^2.0.0",
+        "sha256-universal": "^1.1.0",
+        "sha512-universal": "^1.1.0",
+        "siphash24": "^1.0.1",
+        "xsalsa20": "^1.0.0"
+      }
+    },
+    "node_modules/sodium-native": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.0.5.tgz",
+      "integrity": "sha512-YGimGhy7Ho6pTAAvuNdn3Tv9C2MD7HP89X1omReHat0Fd1mMnapGqwzb5YoHTAbIEh8tQmKP6+uLlwYCkf+EOA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.6.0"
+      }
+    },
+    "node_modules/sodium-universal": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.0.tgz",
+      "integrity": "sha512-iKHl8XnBV96k1c75gwwzANFdephw/MDWSjQAjPmBE+du0y3P23Q8uf7AcdcfFsYAMwLg7WVBfSAIBtV/JvRsjA==",
+      "dependencies": {
+        "blake2b": "^2.1.1",
+        "chacha20-universal": "^1.0.4",
+        "nanoassert": "^2.0.0",
+        "sha256-universal": "^1.1.0",
+        "sha512-universal": "^1.1.0",
+        "siphash24": "^1.0.1",
+        "sodium-javascript": "~0.8.0",
+        "sodium-native": "^4.0.0",
+        "xsalsa20": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -5471,6 +5805,14 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8-util": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/uint8-util/-/uint8-util-2.2.4.tgz",
+      "integrity": "sha512-uEI5lLozmKQPYEevfEhP9LY3Je5ZmrQhaWXrzTVqrLNQl36xsRh8NiAxYwB9J+2BAt99TRbmCkROQB2ZKhx4UA==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
     "node_modules/uint8arrays": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
@@ -5672,6 +6014,11 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/xsalsa20": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
+      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -5747,6 +6094,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/z32/-/z32-1.0.1.tgz",
+      "integrity": "sha512-Uytfqf6VEVchHKZDw0NRdCViOARHP84uzvOw0CXCMLOwhgHZUL9XibpEPLLQN10mCVLxOlGCQWbkV7km7yNYcw==",
+      "dependencies": {
+        "b4a": "^1.5.3"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@tbdex/http-server": "0.23.0",
-        "@web5/common": "0.2.1",
-        "@web5/crypto": "0.2.1",
-        "@web5/dids": "0.2.1",
+        "@web5/common": "0.2.2",
+        "@web5/crypto": "0.3.0",
+        "@web5/dids": "0.2.4",
         "ajv": "8.12.0",
         "cborg": "^3.0.0",
         "dotenv": "16.3.1",
@@ -539,6 +539,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@tbdex/http-client/node_modules/@web5/common": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.1.tgz",
+      "integrity": "sha512-Tt5P17HgQCx+Epw0IHnhRKqp5UU3E4xtsE8PkdghOBnvntBB0op5P6efvR1WqmJft5+VunDHt3yZAZstuqQkNg==",
+      "dependencies": {
+        "level": "8.0.0",
+        "multiformats": "11.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@tbdex/http-client/node_modules/@web5/crypto": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.2.tgz",
@@ -596,6 +608,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@tbdex/http-server/node_modules/@web5/common": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.1.tgz",
+      "integrity": "sha512-Tt5P17HgQCx+Epw0IHnhRKqp5UU3E4xtsE8PkdghOBnvntBB0op5P6efvR1WqmJft5+VunDHt3yZAZstuqQkNg==",
+      "dependencies": {
+        "level": "8.0.0",
+        "multiformats": "11.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@tbdex/http-server/node_modules/@web5/crypto": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.2.tgz",
@@ -644,6 +668,18 @@
         "bignumber.js": "^9.1.2",
         "canonicalize": "2.0.0",
         "typeid-js": "0.3.0"
+      }
+    },
+    "node_modules/@tbdex/protocol/node_modules/@web5/common": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.1.tgz",
+      "integrity": "sha512-Tt5P17HgQCx+Epw0IHnhRKqp5UU3E4xtsE8PkdghOBnvntBB0op5P6efvR1WqmJft5+VunDHt3yZAZstuqQkNg==",
+      "dependencies": {
+        "level": "8.0.0",
+        "multiformats": "11.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@tbdex/protocol/node_modules/@web5/crypto": {
@@ -1085,12 +1121,13 @@
       }
     },
     "node_modules/@web5/common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.1.tgz",
-      "integrity": "sha512-Tt5P17HgQCx+Epw0IHnhRKqp5UU3E4xtsE8PkdghOBnvntBB0op5P6efvR1WqmJft5+VunDHt3yZAZstuqQkNg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.2.tgz",
+      "integrity": "sha512-dRn6SmALExeTLMTK/W5ozGarfaddK+Lraf5OjuIGLAaLfcX1RWx3oDMoY5Hr9LjfxHJC8mGXB8DnKflbeYJRgA==",
       "dependencies": {
         "level": "8.0.0",
-        "multiformats": "11.0.2"
+        "multiformats": "11.0.2",
+        "readable-stream": "4.4.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1110,20 +1147,70 @@
       }
     },
     "node_modules/@web5/crypto": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.1.tgz",
-      "integrity": "sha512-DM49030ftALhzXipYdsxfCexdSNJxlnj++YUiM+lbf9aEOxT3PCapDMSXi0MG1flPJHu/Q/LMebMN/aAr0WJ3A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.3.0.tgz",
+      "integrity": "sha512-0loHY6mTDUA7/Y2WzZmbozHclX9GI0lW8m/ocnr8GpwHzutY7uQGizJsiidB4Z7Jg44Y9MCZYVqxNHvw1ZsRBA==",
       "dependencies": {
-        "@noble/ciphers": "0.1.4",
-        "@noble/curves": "1.1.0",
-        "@noble/hashes": "1.3.1",
-        "@web5/common": "0.2.1"
+        "@noble/ciphers": "0.4.1",
+        "@noble/curves": "1.3.0",
+        "@noble/hashes": "1.3.3",
+        "@web5/common": "0.2.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@web5/crypto/node_modules/@noble/ciphers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.4.1.tgz",
+      "integrity": "sha512-QCOA9cgf3Rc33owG0AYBB9wszz+Ul2kramWN8tXG44Gyciud/tbkEqvxRF/IpqQaBpRBNi9f4jdNxqB2CQCIXg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web5/crypto/node_modules/@noble/curves": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dependencies": {
+        "@noble/hashes": "1.3.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@web5/crypto/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web5/dids": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.4.tgz",
+      "integrity": "sha512-e+m+xgpiM8ydTJgWcPdwmjILLMZYdl2kwahlO22mK0azSKVrg1klpGrUODzqkrWrQ5O0tnOyqEy39FcD5Sy11w==",
+      "dependencies": {
+        "@decentralized-identity/ion-pow-sdk": "1.0.17",
+        "@decentralized-identity/ion-sdk": "1.0.1",
+        "@web5/common": "0.2.2",
+        "@web5/crypto": "0.2.2",
+        "did-resolver": "4.1.0",
+        "dns-packet": "5.6.1",
+        "level": "8.0.0",
+        "ms": "2.1.3",
+        "pkarr": "1.1.1",
+        "z32": "1.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web5/dids/node_modules/@noble/hashes": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
       "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
@@ -1134,22 +1221,41 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@web5/dids": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.1.tgz",
-      "integrity": "sha512-9t7AlUlb9mUBTaX5jK8AC7gTuikCic6ewHfWtaZ4TuDf5qi1PRhczmbm1h8zh7gVTd0zke8TR6QiBd9RyneSGA==",
+    "node_modules/@web5/dids/node_modules/@web5/crypto": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.2.tgz",
+      "integrity": "sha512-vHFg0wXQSQXrwuBNQyDHnmSZchfTfO6/Sv+7rDsNkvofs+6lGTE8CZ02cwUYMeIwTRMLer12c+fMfzYrXokEUQ==",
       "dependencies": {
-        "@decentralized-identity/ion-pow-sdk": "1.0.17",
-        "@decentralized-identity/ion-sdk": "1.0.1",
-        "@web5/common": "0.2.1",
-        "@web5/crypto": "0.2.1",
-        "canonicalize": "2.0.0",
-        "did-resolver": "4.1.0",
-        "level": "8.0.0",
-        "ms": "2.1.3"
+        "@noble/ciphers": "0.1.4",
+        "@noble/curves": "1.1.0",
+        "@noble/hashes": "1.3.1",
+        "@web5/common": "0.2.1"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web5/dids/node_modules/@web5/crypto/node_modules/@web5/common": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.1.tgz",
+      "integrity": "sha512-Tt5P17HgQCx+Epw0IHnhRKqp5UU3E4xtsE8PkdghOBnvntBB0op5P6efvR1WqmJft5+VunDHt3yZAZstuqQkNg==",
+      "dependencies": {
+        "level": "8.0.0",
+        "multiformats": "11.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/abstract-level": {
@@ -2572,6 +2678,22 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/express": {
@@ -4749,6 +4871,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4846,6 +4976,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/readdirp": {
@@ -5448,6 +5593,14 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "1.0.0",
   "dependencies": {
-    "@tbdex/http-server": "0.18.0",
+    "@tbdex/http-server": "0.23.0",
     "@web5/common": "0.2.1",
     "@web5/crypto": "0.2.1",
     "@web5/dids": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "1.0.0",
   "dependencies": {
     "@tbdex/http-server": "0.23.0",
-    "@web5/common": "0.2.1",
-    "@web5/crypto": "0.2.1",
-    "@web5/dids": "0.2.1",
+    "@web5/common": "0.2.2",
+    "@web5/crypto": "0.3.0",
+    "@web5/dids": "0.2.4",
     "ajv": "8.12.0",
     "cborg": "^3.0.0",
     "dotenv": "16.3.1",

--- a/src/client-test.ts
+++ b/src/client-test.ts
@@ -59,17 +59,13 @@ const rfq = Rfq.create({
     payinAmount: '100.00',
     payinMethod: {
       kind: 'USD_LEDGER',
-      paymentDetails: {
-        cvv: '123',
-        cardNumber: '1234567890123456789',
-        expiryDate: '10/23',
-        cardHolderName: 'Ephraim Mcgilacutti'
-      }
+      paymentDetails: {}
     },
     payoutMethod: {
-      kind: 'BTC_ADDRESS',
+      kind: 'BANK_FIRSTBANK',
       paymentDetails: {
-        btcAddress: '0x1234567890'
+        accountNumber: '0x1234567890',
+        reason: 'I got kids'
       }
     },
     claims: [signedCredential]

--- a/src/client-test.ts
+++ b/src/client-test.ts
@@ -15,8 +15,7 @@ let PFI_DID = await fs.readFile('server-did.txt', 'utf-8')
 //
 //  Connect to the PFI and get the list of offerings (offerings are resources - anyone can ask for them)
 //
-const { data } = await TbdexHttpClient.getOfferings({ pfiDid: PFI_DID })
-const [ offering ] = data
+const [ offering ] = await TbdexHttpClient.getOfferings({ pfiDid: PFI_DID })
 //console.log('offering', JSON.stringify(offering, null, 2))
 
 
@@ -36,10 +35,6 @@ console.log('issuer did:', issuer.did)
 //
 // Create a did for Alice, who is the customer of the PFI in this case.
 const alice = await createOrLoadDid('alice.json')
-
-
-const { privateKeyJwk } = alice.keySet.verificationMethodKeys[0]
-const kid = alice.document.verificationMethod[0].id
 
 //
 //
@@ -61,9 +56,9 @@ const rfq = Rfq.create({
   metadata: { from: alice.did, to: PFI_DID },
   data: {
     offeringId: offering.id,
-    payinSubunits: '100',
+    payinAmount: '100.00',
     payinMethod: {
-      kind: 'DEBIT_CARD',
+      kind: 'USD_LEDGER',
       paymentDetails: {
         cvv: '123',
         cardNumber: '1234567890123456789',
@@ -81,7 +76,7 @@ const rfq = Rfq.create({
   }
 })
 
-await rfq.sign(privateKeyJwk, kid)
+await rfq.sign(alice)
 
 const rasp = await TbdexHttpClient.sendMessage({ message: rfq })
 console.log('send rfq response', JSON.stringify(rasp, null, 2))
@@ -92,9 +87,8 @@ console.log('send rfq response', JSON.stringify(rasp, null, 2))
 // This is where for example a quote would show up in result to an RFQ.
 const exchanges = await TbdexHttpClient.getExchanges({
   pfiDid: PFI_DID,
-  filter: { id: rfq.exchangeId },
-  privateKeyJwk,
-  kid
+  did: alice,
+  filter: { id: rfq.exchangeId }
 })
 
 console.log('exchanges', JSON.stringify(exchanges, null, 2))

--- a/src/db/exchange-repository.ts
+++ b/src/db/exchange-repository.ts
@@ -138,73 +138,70 @@ class _ExchangeRepository implements ExchangesApi {
 
     if (message.kind == 'rfq') {
       const quote = Quote.create({
-          metadata: {
-            from: config.did.id,
-            to: message.from,
-            exchangeId: message.exchangeId
+        metadata: {
+          from: config.did.did,
+          to: message.from,
+          exchangeId: message.exchangeId
+        },
+        data: {
+          expiresAt: new Date(2024, 4, 1).toISOString(),
+          payin: {
+            currencyCode: 'BTC',
+            amount: '1000.00'
           },
-          data: {
-            expiresAt: new Date(2024, 4, 1).toISOString(),
-            payin: {
-              currencyCode: 'BTC',
-              amountSubunits: '1000'
-            },
-            payout: {
-              currencyCode: 'KES',
-              amountSubunits: '123456789'
-            }
+          payout: {
+            currencyCode: 'KES',
+            amount: '123456789.00'
           }
         }
-      )
-      await quote.sign(config.did.privateKey, config.did.kid)
+      })
+      await quote.sign(config.did)
       this.addMessage({ message: quote as Quote})
     }
 
     if (message.kind == 'order') {
       let orderStatus = OrderStatus.create({
-          metadata: {
-            from: config.did.id,
-            to: message.from,
-            exchangeId: message.exchangeId
-          },
-          data: {
-            orderStatus: 'PROCESSING'
-          }
+        metadata: {
+          from: config.did.did,
+          to: message.from,
+          exchangeId: message.exchangeId
+        },
+        data: {
+          orderStatus: 'PROCESSING'
         }
-      )
-      await orderStatus.sign(config.did.privateKey, config.did.kid)
+      })
+      await orderStatus.sign(config.did)
       this.addMessage({ message: orderStatus as OrderStatus})
 
-      await new Promise(resolve => setTimeout(resolve, 1000)); // 1 second delay
+      await new Promise(resolve => setTimeout(resolve, 1000)) // 1 second delay
 
       orderStatus = OrderStatus.create({
-          metadata: {
-            from: config.did.id,
-            to: message.from,
-            exchangeId: message.exchangeId
-          },
-          data: {
-            orderStatus: 'COMPLETED'
-          }
+        metadata: {
+          from: config.did.did,
+          to: message.from,
+          exchangeId: message.exchangeId
+        },
+        data: {
+          orderStatus: 'COMPLETED'
         }
-      )
-      await orderStatus.sign(config.did.privateKey, config.did.kid)
+      })
+      await orderStatus.sign(config.did)
       this.addMessage({ message: orderStatus as OrderStatus})
 
       // finally close the exchange
       const close = Close.create({
         metadata: {
-          from: config.did.id,
+          from: config.did.did,
           to: message.from,
           exchangeId: message.exchangeId
         },
         data: {
           reason: 'Order fulfilled'
         }
-      });
-      await close.sign(config.did.privateKey, config.did.kid)
+      })
+      await close.sign(config.did)
       this.addMessage({ message: close as Close })
-    } 
+    }
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,9 +50,7 @@ const server = httpApi.listen(config.port, () => {
   log.info(`Mock PFI listening on port ${config.port}`)
 })
 
-console.log('PFI DID: ', config.did.id)
-console.log('PFI DID KEY: ', JSON.stringify(config.did.privateKey))
-console.log('PFI KID: ', config.did.kid)
+console.log('PFI DID: ', config.did.did)
 
 httpApi.api.get('/', (req, res) => {
   res.send('Please use the tbdex protocol to communicate with this server or a suitable library: https://github.com/TBD54566975/tbdex-protocol')

--- a/src/seed-offerings.ts
+++ b/src/seed-offerings.ts
@@ -9,7 +9,7 @@ await Postgres.connect()
 await Postgres.clear()
 
 const offering = Offering.create({
-  metadata: { from: config.did.id },
+  metadata: { from: config.did.did },
   data: {
     description: 'fake offering 1',
     payoutUnitsPerPayinUnit: '0.0069', // ex. we send 100 dollars, so that means 14550.00 KES
@@ -100,5 +100,5 @@ const offering = Offering.create({
   }
 })
 
-await offering.sign(config.did.privateKey, config.did.kid)
+await offering.sign(config.did)
 await OfferingRepository.create(offering)


### PR DESCRIPTION
There's been a bunch of changes to tbDEX, this PR pulls those in and makes the necessary changes to get the examples up and running again!

Note on the `.env.example` changes:
* Signing now requires a `PortableDid`, and not the various parts of the Did (like JWK, KID, etc.). I didn't see a way to re-construct a `PortableDid` from disk, so I went ahead and just removed that bit from the sample env file. If anyone knows of a way to do this, I'd love to update this to maintain the functionality!