### PR TITLE
Address `shellcheck` error and warnings

### DIFF
--- a/db/scripts/common
+++ b/db/scripts/common
@@ -20,3 +20,25 @@ export DATABASE_URL="postgres://$DP_SEC_DB_USER:$DP_SEC_DB_PASSWORD@$DP_SEC_DB_H
 RED="$(tput bold && tput setaf 1)"
 YELLOW="$(tput bold && tput setaf 3)"
 RESET="$(tput sgr0)"
+
+_logger() {
+	local color="$1"
+	local level="$2"
+	shift 2
+
+	local message="$*"
+	local current_datetime="$(date +'%F %T')"
+	printf "%s%s%10s%s%s\n" "$color" "$current_datetime" "$level - " "$message" "$RESET"
+}
+
+error() {
+	_logger "$RED" "ERROR" "$*"
+}
+
+warn() {
+	_logger "$YELLOW" "WARN" "$*"
+}
+
+info() {
+	_logger "$RESET" "INFO" "$*"
+}

--- a/db/scripts/common
+++ b/db/scripts/common
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script contains variables used in all of the other scripts in this directory
 

--- a/db/scripts/common
+++ b/db/scripts/common
@@ -6,11 +6,11 @@
 THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
 # variables with defaults. these are overridden by our deployment infra in staging and prod
-: ${DP_SEC_DB_USER:="postgres"}
-: ${DP_SEC_DB_PASSWORD:="tbd"}
-: ${DP_SEC_DB_HOST:="localhost"}
-: ${DP_SEC_DB_PORT:="5432"}
-: ${DP_SEC_DB_NAME:="mockpfi"}
+: "${DP_SEC_DB_USER:="postgres"}"
+: "${DP_SEC_DB_PASSWORD:="tbd"}"
+: "${DP_SEC_DB_HOST:="localhost"}"
+: "${DP_SEC_DB_PORT:="5432"}"
+: "${DP_SEC_DB_NAME:="mockpfi"}"
 
 # these are exported because they're used by child processes (e.g. dbmate)
 export DATABASE_URL=postgres://$DP_SEC_DB_USER:$DP_SEC_DB_PASSWORD@$DP_SEC_DB_HOST:$DP_SEC_DB_PORT/$DP_SEC_DB_NAME?sslmode=disable

--- a/db/scripts/common
+++ b/db/scripts/common
@@ -13,8 +13,8 @@ THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 : "${DP_SEC_DB_NAME:="mockpfi"}"
 
 # these are exported because they're used by child processes (e.g. dbmate)
-export DATABASE_URL=postgres://$DP_SEC_DB_USER:$DP_SEC_DB_PASSWORD@$DP_SEC_DB_HOST:$DP_SEC_DB_PORT/$DP_SEC_DB_NAME?sslmode=disable
 export DBMATE_MIGRATIONS_DIR=$THIS_DIR/../migrations
+export DATABASE_URL="postgres://$DP_SEC_DB_USER:$DP_SEC_DB_PASSWORD@$DP_SEC_DB_HOST:$DP_SEC_DB_PORT/$DP_SEC_DB_NAME?sslmode=disable"
 
 # colors that can be used in bash scripts when echoing
 RED="$(tput bold && tput setaf 1)"

--- a/db/scripts/common
+++ b/db/scripts/common
@@ -17,5 +17,6 @@ export DATABASE_URL=postgres://$DP_SEC_DB_USER:$DP_SEC_DB_PASSWORD@$DP_SEC_DB_HO
 export DBMATE_MIGRATIONS_DIR=$THIS_DIR/../migrations
 
 # colors that can be used in bash scripts when echoing
-YELLOW='\033[33m'
-RESET='\033[0m'
+RED="$(tput bold && tput setaf 1)"
+YELLOW="$(tput bold && tput setaf 3)"
+RESET="$(tput sgr0)"

--- a/db/scripts/common
+++ b/db/scripts/common
@@ -3,7 +3,7 @@
 # This script contains variables used in all of the other scripts in this directory
 
 # neckbeard bash used to get the value of _this_ directory.
-THIS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
 # variables with defaults. these are overridden by our deployment infra in staging and prod
 : ${DP_SEC_DB_USER:="postgres"}

--- a/db/scripts/local
+++ b/db/scripts/local
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script contains variables used in scripts that are for running locally
 

--- a/db/scripts/local
+++ b/db/scripts/local
@@ -2,6 +2,18 @@
 
 # This script contains variables used in scripts that are for running locally
 
+get_container() {
+	local name=$1
+	local status=$2
+	docker ps \
+		--all \
+		--quiet \
+		--filter name="$name" \
+		--filter status="$status"
+}
+
 CONTAINER_NAME=mock-pfi-pg
-RUNNING_CONTAINER=$(docker ps -aq --filter name=$CONTAINER_NAME --filter status=running)
-STOPPED_CONTAINER=$(docker ps -aq --filter name=$CONTAINER_NAME --filter status=exited)
+# shellcheck disable=SC2034
+RUNNING_CONTAINER="$(get_container $CONTAINER_NAME running)"
+# shellcheck disable=SC2034
+STOPPED_CONTAINER="$(get_container $CONTAINER_NAME exited)"

--- a/db/scripts/migrate
+++ b/db/scripts/migrate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script runs db migrations. environment variables can be found in `common`
 THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)

--- a/db/scripts/migrate
+++ b/db/scripts/migrate
@@ -4,16 +4,16 @@
 THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source "$THIS_DIR/common"
 
-if [ -d "$DBMATE_MIGRATIONS_DIR" ] && [ -n "($ls -A $DBMATE_MIGRATIONS_DIR)" ]; then
-	echo "$(date '+%Y-%m-%d %H:%M:%S')  Running migrations for postgres://$DP_SEC_DB_USER:****@$DP_SEC_DB_HOST:$DP_SEC_DB_PORT/$DP_SEC_DB_NAME?sslmode=disable"
-	dbmate --wait --wait-timeout=60s up
-
-	if [ $? -eq 0 ]; then
-		echo "$(date '+%Y-%m-%d %H:%M:%S')  Completed migrations"
-	else
-		echo "$(date '+%Y-%m-%d %H:%M:%S')  Migrations failed."
+if [ -d "$DBMATE_MIGRATIONS_DIR" ]; then
+	if [ -z "$(command ls -A1 "$DBMATE_MIGRATIONS_DIR")" ]; then
+		info "No migrations found."
+		exit 0
 	fi
 
-else
-	echo "$(date '+%Y-%m-%d %H:%M:%S')  No Migrations Present."
+	info "Running migrations for postgres://$DP_SEC_DB_USER:****@$DP_SEC_DB_HOST:$DP_SEC_DB_PORT/$DP_SEC_DB_NAME?sslmode=disable"
+	if dbmate --wait --wait-timeout=60s up; then
+		info "Migrations completed successfully."
+	else
+		error "Migrations failed."
+	fi
 fi

--- a/db/scripts/migrate
+++ b/db/scripts/migrate
@@ -2,8 +2,8 @@
 
 # This script runs db migrations. environment variables can be found in `common`
 
-THIS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-source $THIS_DIR/common
+THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+source "$THIS_DIR/common"
 
 if [ -d "$DBMATE_MIGRATIONS_DIR" ] && [ -n "($ls -A $DBMATE_MIGRATIONS_DIR)" ]; then
 	echo "$(date '+%Y-%m-%d %H:%M:%S')  Running migrations for postgres://$DP_SEC_DB_USER:****@$DP_SEC_DB_HOST:$DP_SEC_DB_PORT/$DP_SEC_DB_NAME?sslmode=disable"

--- a/db/scripts/migrate
+++ b/db/scripts/migrate
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # This script runs db migrations. environment variables can be found in `common`
-
 THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source "$THIS_DIR/common"
 

--- a/db/scripts/new-migration
+++ b/db/scripts/new-migration
@@ -5,4 +5,4 @@
 THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source "$THIS_DIR/common"
 
-dbmate new $@
+dbmate new "$@"

--- a/db/scripts/new-migration
+++ b/db/scripts/new-migration
@@ -2,7 +2,7 @@
 
 # This script creates a new migration file
 
-THIS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source $THIS_DIR/common
 
 dbmate new $@

--- a/db/scripts/new-migration
+++ b/db/scripts/new-migration
@@ -3,6 +3,6 @@
 # This script creates a new migration file
 
 THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-source $THIS_DIR/common
+source "$THIS_DIR/common"
 
 dbmate new $@

--- a/db/scripts/new-migration
+++ b/db/scripts/new-migration
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # This script creates a new migration file
 

--- a/db/scripts/start-pg
+++ b/db/scripts/start-pg
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # this script starts dockerized mysql if it isn't already running.
 

--- a/db/scripts/start-pg
+++ b/db/scripts/start-pg
@@ -2,23 +2,23 @@
 
 # this script starts dockerized mysql if it isn't already running.
 
-THIS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source $THIS_DIR/common
 source $THIS_DIR/local
 
 if [ -n "$RUNNING_CONTAINER" ]; then
-  echo "Container $CONTAINER_NAME is already running"
+	echo "Container $CONTAINER_NAME is already running"
 elif [ -n "$STOPPED_CONTAINER" ]; then
-  echo "Starting $CONTAINER_NAME"
-  docker start $CONTAINER_NAME
+	echo "Starting $CONTAINER_NAME"
+	docker start $CONTAINER_NAME
 else
-  echo "Creating & starting $CONTAINER_NAME"
-  docker run --detach \
-    --name $CONTAINER_NAME \
-    --env POSTGRES_USER=$DP_SEC_DB_USER \
-    --env POSTGRES_DB=$DP_SEC_DB_NAME \
-    --env POSTGRES_PASSWORD=$DP_SEC_DB_PASSWORD \
-    --env PGSSLMODE=disable \
-    --publish $DP_SEC_DB_PORT:5432 \
-    postgres:15.4
+	echo "Creating & starting $CONTAINER_NAME"
+	docker run --detach \
+		--name $CONTAINER_NAME \
+		--env POSTGRES_USER=$DP_SEC_DB_USER \
+		--env POSTGRES_DB=$DP_SEC_DB_NAME \
+		--env POSTGRES_PASSWORD=$DP_SEC_DB_PASSWORD \
+		--env PGSSLMODE=disable \
+		--publish $DP_SEC_DB_PORT:5432 \
+		postgres:15.4
 fi

--- a/db/scripts/start-pg
+++ b/db/scripts/start-pg
@@ -3,8 +3,8 @@
 # this script starts dockerized mysql if it isn't already running.
 
 THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-source $THIS_DIR/common
-source $THIS_DIR/local
+source "$THIS_DIR/common"
+source "$THIS_DIR/local"
 
 if [ -n "$RUNNING_CONTAINER" ]; then
 	echo "Container $CONTAINER_NAME is already running"
@@ -14,11 +14,11 @@ elif [ -n "$STOPPED_CONTAINER" ]; then
 else
 	echo "Creating & starting $CONTAINER_NAME"
 	docker run --detach \
-		--name $CONTAINER_NAME \
-		--env POSTGRES_USER=$DP_SEC_DB_USER \
-		--env POSTGRES_DB=$DP_SEC_DB_NAME \
-		--env POSTGRES_PASSWORD=$DP_SEC_DB_PASSWORD \
-		--env PGSSLMODE=disable \
-		--publish $DP_SEC_DB_PORT:5432 \
+		--name "$CONTAINER_NAME" \
+		--env "POSTGRES_USER=$DP_SEC_DB_USER" \
+		--env "POSTGRES_DB=$DP_SEC_DB_NAME" \
+		--env "POSTGRES_PASSWORD=$DP_SEC_DB_PASSWORD" \
+		--env "PGSSLMODE=disable" \
+		--publish "$DP_SEC_DB_PORT:5432" \
 		postgres:15.4
 fi

--- a/db/scripts/stop-pg
+++ b/db/scripts/stop-pg
@@ -1,18 +1,18 @@
 #! /bin/bash
 
-# This script stops dockerized mysql if it isn't already running. passing -rm will delete the 
+# This script stops dockerized mysql if it isn't already running. passing -rm will delete the
 # container as well
 
-THIS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source $THIS_DIR/common
 source $THIS_DIR/local
 
 if [ -z "$STOPPED_CONTAINER" ]; then
-  echo "stopping $CONTAINER_NAME"
-  docker container stop $CONTAINER_NAME
+	echo "stopping $CONTAINER_NAME"
+	docker container stop $CONTAINER_NAME
 fi
 
 if [[ " $* " =~ " -rm " ]]; then
-  echo "Removing $CONTAINER_NAME"
-  docker rm $CONTAINER_NAME
+	echo "Removing $CONTAINER_NAME"
+	docker rm $CONTAINER_NAME
 fi

--- a/db/scripts/stop-pg
+++ b/db/scripts/stop-pg
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # This script stops dockerized mysql if it isn't already running. passing -rm will delete the
 # container as well

--- a/db/scripts/stop-pg
+++ b/db/scripts/stop-pg
@@ -4,8 +4,8 @@
 # container as well
 
 THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-source $THIS_DIR/common
-source $THIS_DIR/local
+source "$THIS_DIR/common"
+source "$THIS_DIR/local"
 
 if [ -z "$STOPPED_CONTAINER" ]; then
 	echo "stopping $CONTAINER_NAME"

--- a/db/scripts/use-pg
+++ b/db/scripts/use-pg
@@ -8,7 +8,7 @@ source "$THIS_DIR/local"
 
 if [ -n "$RUNNING_CONTAINER" ]; then
 	echo "Using $CONTAINER_NAME"
-	docker exec -it "$CONTAINER_NAME" psql -U "$DP_SEC_DB_USER"
+	docker exec --interactive --tty "$CONTAINER_NAME" psql --username "$DP_SEC_DB_USER"
 else
 	echo "$CONTAINER_NAME is not currently running, use the start-pg command first"
 fi

--- a/db/scripts/use-pg
+++ b/db/scripts/use-pg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script drops you into a mysql shell.
 

--- a/db/scripts/use-pg
+++ b/db/scripts/use-pg
@@ -2,13 +2,13 @@
 
 # This script drops you into a mysql shell.
 
-THIS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source $THIS_DIR/common
 source $THIS_DIR/local
 
-if [ -n "$RUNNING_CONTAINER" ]; then 
-  echo "Using $CONTAINER_NAME"
-  docker exec -it $CONTAINER_NAME psql -U $DP_SEC_DB_USER
+if [ -n "$RUNNING_CONTAINER" ]; then
+	echo "Using $CONTAINER_NAME"
+	docker exec -it $CONTAINER_NAME psql -U $DP_SEC_DB_USER
 else
-  echo "$CONTAINER_NAME is not currently running, use the start-pg command first"
+	echo "$CONTAINER_NAME is not currently running, use the start-pg command first"
 fi

--- a/db/scripts/use-pg
+++ b/db/scripts/use-pg
@@ -3,12 +3,12 @@
 # This script drops you into a mysql shell.
 
 THIS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-source $THIS_DIR/common
-source $THIS_DIR/local
+source "$THIS_DIR/common"
+source "$THIS_DIR/local"
 
 if [ -n "$RUNNING_CONTAINER" ]; then
 	echo "Using $CONTAINER_NAME"
-	docker exec -it $CONTAINER_NAME psql -U $DP_SEC_DB_USER
+	docker exec -it "$CONTAINER_NAME" psql -U "$DP_SEC_DB_USER"
 else
 	echo "$CONTAINER_NAME is not currently running, use the start-pg command first"
 fi


### PR DESCRIPTION
 - [x] addressed a handful of `shellcheck` warnings and errors
     - [x] [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086)
     - [x] [SC2125](https://github.com/koalaman/shellcheck/wiki/SC2125)
     - [x] [SC2223](https://github.com/koalaman/shellcheck/wiki/SC2223)
 - [x] applied `shfmt` for consistent style, used `env bash` for portability
 - [x] use `--long-options` for self-documenting features
 - [x] added color support for logging (`RED` and `YELLOW` were unused, but I think I captured the intent of where they _might_ be used
 - [x] replace color escape codes with `tput` for unsupported/non-tty `$TERM`s