### PR TITLE
Make Quote expiration date dynamic

### DIFF
--- a/src/db/exchange-repository.ts
+++ b/src/db/exchange-repository.ts
@@ -147,7 +147,7 @@ class _ExchangeRepository implements ExchangesApi {
           exchangeId: message.exchangeId
         },
         data: {
-          expiresAt: new Date(2024, 4, 1).toISOString(),
+          expiresAt: new Date(new Date().getTime() + 60 * 60000).toISOString(),
           payin: {
             currencyCode: 'BTC',
             amount: '1000.00'


### PR DESCRIPTION
Fixes #37 by making Quotes expire 1 hour from the current time vs using a hard-coded date (which has already passed)